### PR TITLE
Minor improvement: Cards and comments show in descending order for better admin experience

### DIFF
--- a/app/admin/controller/Cards.php
+++ b/app/admin/controller/Cards.php
@@ -24,6 +24,7 @@ class Cards
         //获取列表
         $listNum = 12; //每页个数
         $list = Db::table('cards')
+            ->order('id', 'desc')
             ->paginate($listNum, true);
         View::assign([
             'list'  => $list,

--- a/app/admin/controller/CardsComments.php
+++ b/app/admin/controller/CardsComments.php
@@ -23,6 +23,7 @@ class CardsComments
         //获取列表
         $listNum = 12; //每页个数
         $list = Db::table('cards_comments')
+            ->order('id', 'desc')
             ->paginate($listNum, true);
         View::assign([
             'list'  => $list,

--- a/app/admin/controller/CardsComments.php
+++ b/app/admin/controller/CardsComments.php
@@ -23,7 +23,7 @@ class CardsComments
         //获取列表
         $listNum = 12; //每页个数
         $list = Db::table('cards_comments')
-            ->order('id', 'desc')
+            ->order('cid', 'desc')
             ->paginate($listNum, true);
         View::assign([
             'list'  => $list,


### PR DESCRIPTION
Add ->order('id', 'desc') to order cards and add ->order('cid', 'desc') to order comments for better admin experience. The current experience is awful when admins check new cards and comments.